### PR TITLE
updated SimpleLatLng version to 1.3.0

### DIFF
--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -28,6 +28,6 @@ grails.project.dependency.resolution = {
         // specify dependencies here under either 'build', 'compile', 'runtime', 'test' or 'provided' scopes eg.
 
         // runtime 'mysql:mysql-connector-java:5.1.13'
-		runtime 'com.javadocmd:simplelatlng:1.0.0'
+		runtime 'com.javadocmd:simplelatlng:1.3.0'
     }
 }


### PR DESCRIPTION
According to the [Version History](https://code.google.com/p/simplelatlng/wiki/VersionHistory) section in the project's site at Google Code, some harmful bugs have been fixed.
